### PR TITLE
fix(shell): Fix some possible undefined behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ keystore.jks
 conf/keystore.jks.base64
 data/
 .idea/
+
+# authentication data
+.cookie
+.current
+.email
+.password


### PR DESCRIPTION
This PR will
- use `bash` instead of `sh` since `read -p` is not POSIX-compliant
- add a check if `jq` and `curl` are installed and exit otherwise
- fix some possible globbing and word splitting
- add authentication data files to the list of ignored files