### PR TITLE
Update runtime image to the latest available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . ./
 RUN mvn -Dmaven.test.skip=true package
 
 # runtime stage
-FROM dejankovacevic/bots.runtime:2.10.3
+FROM wirebot/runtime
 
 WORKDIR /opt/echo
 
@@ -30,4 +30,4 @@ ENV RELEASE_FILE_PATH=/opt/echo/release.txt
 RUN echo $release_version > $RELEASE_FILE_PATH
 
 EXPOSE  8080 8081 8082
-ENTRYPOINT ["java", "-javaagent:/opt/wire/lib/jmx_prometheus_javaagent.jar=8082:/opt/wire/lib/metrics.yaml", "-jar", "echo.jar", "server", "echo.yaml"]
+ENTRYPOINT ["java", "-javaagent:/opt/wire/lib/prometheus-agent.jar=8082:/opt/wire/lib/metrics.yaml", "-jar", "echo.jar", "server", "echo.yaml"]


### PR DESCRIPTION
* use runtime image from this PR https://github.com/wireapp/cryptobox4j/pull/4
* verified that it works on staging
   * however, as the image is using JVM 11, the Lithium produces warning, we need to update lithium